### PR TITLE
Add "log" library for Android

### DIFF
--- a/android-activity.cabal
+++ b/android-activity.cabal
@@ -25,3 +25,4 @@ library
   install-includes: HaskellActivity.h
   exposed-modules:
     Android.HaskellActivity
+  extra-libraries: log


### PR DESCRIPTION
This resolves a symbol that is not found during linking of executables
using android activity.

Without this patch, I get this on linking reflex-todomvc with newer Android NDK:

```
Linking dist/build/reflex-todomvc/reflex-todomvc ...




/nix/store/ph8w6w4jzw11f64kq2z719bqwvgjkxqf-reflex-dom-0.4-aarch64-unknown-linux-android/lib/ghc-8.4.2/reflex-dom-0.4/libHSreflex-dom-0.4-K8NgevVKial7zvHSW3dCbY.a(MainWidget.o): In function `Reflex_Dom_Android_MainWidget_start':
(.text+0x154): undefined reference to `__android_log_write'
/nix/store/ph8w6w4jzw11f64kq2z719bqwvgjkxqf-reflex-dom-0.4-aarch64-unknown-linux-android/lib/ghc-8.4.2/reflex-dom-0.4/libHSreflex-dom-0.4-K8NgevVKial7zvHSW3dCbY.a(MainWidget.o): In function `Reflex_Dom_Android_MainWidget_runJS':
(.text+0x394): undefined reference to `__android_log_write'
/nix/store/5vhknin27jkx03in98y55nhnwl6aq8rw-android-activity-0.1-aarch64-unknown-linux-android/lib/ghc-8.4.2/android-activity-0.1/libHSandroid-activity-0.1-69z55wJmhCW3RdjkUvRyZR.a(HaskellActivity.o): In function `loggerThread':
(.text+0x40): undefined reference to `__android_log_write'
/nix/store/5vhknin27jkx03in98y55nhnwl6aq8rw-android-activity-0.1-aarch64-unknown-linux-android/lib/ghc-8.4.2/android-activity-0.1/libHSandroid-activity-0.1-69z55wJmhCW3RdjkUvRyZR.a(HaskellActivity.o): In function `loggerThread':
(.text+0x68): undefined reference to `__android_log_write'
/nix/store/5vhknin27jkx03in98y55nhnwl6aq8rw-android-activity-0.1-aarch64-unknown-linux-android/lib/ghc-8.4.2/android-activity-0.1/libHSandroid-activity-0.1-69z55wJmhCW3RdjkUvRyZR.a(HaskellActivity.o): In function `HaskellActivity_continueWithCallbacks':
(.text+0x6b4): undefined reference to `__android_log_write'
/nix/store/5vhknin27jkx03in98y55nhnwl6aq8rw-android-activity-0.1-aarch64-unknown-linux-android/lib/ghc-8.4.2/android-activity-0.1/libHSandroid-activity-0.1-69z55wJmhCW3RdjkUvRyZR.a(HaskellActivity.o):(.text+0x8d0): more undefined references to `__android_log_write' follow
collect2: error: ld returned 1 exit status
`aarch64-unknown-linux-android-cc' failed in phase `Linker'. (Exit code: 1)
builder for '/nix/store/4629975fxcynkv1wbxyf5fvrq7wgpa2c-reflex-todomvc-0.1-aarch64-unknown-linux-android.drv' failed with exit code 1
```