### PR TITLE
Allow RTS to choose number of capabilities and remove jsaddle reference

### DIFF
--- a/cbits/HaskellActivity.c
+++ b/cbits/HaskellActivity.c
@@ -201,7 +201,7 @@ JNIEXPORT int JNICALL Java_systems_obsidian_HaskellActivity_haskellStartMain (JN
   }
 
   static int argc = 5;
-  static char *argv[] = {"jsaddle", "+RTS", "-N2", "-I0", "-RTS"};
+  static char *argv[] = {"HaskellActivity", "+RTS", "-N", "-I0", "-RTS"};
 
   RtsConfig rts_opts = defaultRtsConfig;
   rts_opts.rts_opts_enabled = RtsOptsAll;


### PR DESCRIPTION
Most phones these days have more than two cores. On my Pixel 2 the RTS was
correctly able to identify 8 cores.