### PR TITLE
{ghc,cc}-options: add -fPIC

### DIFF
--- a/android-activity.cabal
+++ b/android-activity.cabal
@@ -27,4 +27,5 @@ library
   exposed-modules:
     Android.HaskellActivity
   extra-libraries: log
-  ghc-options: -Wall -Werror
+  ghc-options: -Wall -Werror -fPIC
+  cc-options: -fPIC


### PR DESCRIPTION
Fixes the error `function startLogger: error: relocation overflow in R_AARCH64_LDST64_ABS_LO12_NC` that happens while linking with reflex-todomvc when using GHC 8.10.4